### PR TITLE
Bugfix: Add fuzz to filename to avoid collisions

### DIFF
--- a/app/assets/javascripts/s3_file_field.js.coffee
+++ b/app/assets/javascripts/s3_file_field.js.coffee
@@ -71,8 +71,16 @@ jQuery.fn.S3FileField = (options) ->
 
     formData: (form) ->
       unique_id = @files[0].unique_id
+      file_key = $this.data('key').replace('{timestamp}', new Date().getTime()).replace('{unique_id}', unique_id)
+
+      # assume ${filename} is present and can be prefixed with a ms_timestamp
+      ms_timestamp = new Date().getTime()
+      random_chars = Math.random().toString(36).substr(2,4)
+      prefixed_filename = "#{ms_timestamp}-#{random_chars}-${filename}"
+      file_key = file_key.replace('${filename}', prefixed_filename)
+
       finalFormData[unique_id] =
-        key: $this.data('key').replace('{timestamp}', new Date().getTime()).replace('{unique_id}', unique_id)
+        key: file_key
         'Content-Type': @files[0].type
         acl: $this.data('acl')
         'AWSAccessKeyId': $this.data('aws-access-key-id')

--- a/lib/s3_file_field/version.rb
+++ b/lib/s3_file_field/version.rb
@@ -1,3 +1,3 @@
 module S3FileField
-  VERSION = "1.3.0"
+  VERSION = "1.3.0.1"
 end


### PR DESCRIPTION
**Description**

This PR prefixes the filename used when uploading to S3 with a millisecond precision timestamp and a random set of chars. This is to avoid collisions when using iOS and other mobile platforms that use the same name when using the Camera app (i.e.: `image.jpeg`).

**What to Test**

- [x] Image uploading still works.

**Screenshot**

![image-upload-name-prefix-fuzz](https://user-images.githubusercontent.com/33198/65905528-bb5ff500-e38e-11e9-9e5c-3bc91dc729e4.png)
